### PR TITLE
Close #LGVISIUM-101: Added the possibily to parse the AWS_S3_Bucket environment variable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,3 +4,4 @@ MLFLOW_TRACKING_URI="http://127.0.0.1:5000"
 AWS_ACCESS_KEY_ID=your_access_key_id
 AWS_SECRET_ACCESS_KEY=your_secret_access_key
 AWS_ENDPOINT=your_endpoint_url
+AWS_S3_BUCKET=your_bucket_name

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
             ],
             "cwd": "${workspaceFolder}",
             "justMyCode": true,
-            "python": "./swisstopo/bin/python3",
+            "python": "${workspaceFolder}/swisstopo/bin/python3",
         },
         {
             "name": "Python: Run label studio to GT",
@@ -31,7 +31,7 @@
             ],
             "cwd": "${workspaceFolder}",
             "justMyCode": true,
-            "python": "./swisstopo/bin/python3",
+            "python": "${workspaceFolder}/swisstopo/bin/python3",
         },
         {
             "name": "API",
@@ -49,7 +49,7 @@
             ],
             "console": "integratedTerminal",
             "justMyCode": true,
-            "python": "./swisstopo/bin/python3",
+            "python": "${workspaceFolder}/swisstopo/bin/python3",
         },
         {
             "name": "Python: Run pytests",
@@ -59,7 +59,7 @@
             "args": [],
             "cwd": "${workspaceFolder}",
             "justMyCode": true,
-            "python": "./swisstopo/bin/python3",
+            "python": "${workspaceFolder}/swisstopo/bin/python3",
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -48,7 +48,8 @@
                 "8002",
             ],
             "console": "integratedTerminal",
-            "justMyCode": true
+            "justMyCode": true,
+            "python": "./swisstopo/bin/python3",
         },
         {
             "name": "Python: Run pytests",

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Please make sure to define the environment variables needed for the API to acces
 aws_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID")
 aws_secret_key_access = os.environ.get("AWS_SECRET_ACCESS_KEY")
 aws_endpoint = os.environ.get("AWS_ENDPOINT")
+aws_s3_bucket = os.environ.get("AWS_S3_BUCKET")
 ```
 
 3. **Start the FastAPI server**
@@ -373,6 +374,7 @@ Add the following lines to your `~/.bashrc`, `~/.bash_profile`, or `~/.zshrc` (d
 export AWS_ACCESS_KEY_ID=your_access_key_id
 export AWS_SECRET_ACCESS_KEY=your_secret_access_key
 export AWS_ENDPOINT=your_endpoint_url
+export AWS_S3_BUCKET=your_bucket_name
 ```
 
 Please note that the endpoint url is in the following format: `https://{bucket}.s3.<RegionName>.amazonaws.com`. This 
@@ -393,6 +395,7 @@ For Command Prompt:
 setx AWS_ACCESS_KEY_ID your_access_key_id
 setx AWS_SECRET_ACCESS_KEY your_secret_access_key
 setx AWS_ENDPOINT your_endpoint_url
+setx AWS_S3_BUCKET your_bucket_name
 ```
 
 For PowerShell:
@@ -401,6 +404,7 @@ For PowerShell:
 $env:AWS_ACCESS_KEY_ID=your_access_key_id
 $env:AWS_SECRET_ACCESS_KEY=your_secret_access_key
 $env:AWS_ENDPOINT=your_endpoint_url
+$env:AWS_S3_BUCKET=your_bucket_name
 ```
 
 4.2.3. **Passing the AWS credentials in an Environment File**
@@ -411,6 +415,7 @@ Another option is to store the credentials in a .env file and load them into you
 AWS_ACCESS_KEY_ID=your_access_key_id
 AWS_SECRET_ACCESS_KEY=your_secret_access_key
 AWS_ENDPOINT=your_endpoint_url
+AWS_S3_BUCKET=your_bucket_name
 ```
 
 You can find an example for such a `.env` file in `.env.template`. If you rename this file to `.env` and add your AWS credentials you should be good to go. 
@@ -462,7 +467,7 @@ docker pull ghcr.io/swisstopo/swissgeol-boreholes-dataextraction-api:edge
 1. a. **Run the docker image from the Terminal**
    
 ```bash
-docker run -d --name swissgeol-boreholes-dataextraction-api -e AWS_ACCESS_KEY_ID=XXX -e AWS_SECRET_ACCESS_KEY=YYY -e AWS_ENDPOINT=ZZZ -p 8000:8000 ghcr.io/swisstopo/swissgeol-boreholes-dataextraction-api:TAG
+docker run -d --name swissgeol-boreholes-dataextraction-api -e AWS_ACCESS_KEY_ID=XXX -e AWS_SECRET_ACCESS_KEY=YYY -e AWS_S3_BUCKET=AAA -e AWS_ENDPOINT=ZZZ -p 8000:8000 ghcr.io/swisstopo/swissgeol-boreholes-dataextraction-api:TAG
 ```
 
 Adjust the port mapping (8000:8000) based on the app's requirements.

--- a/README.md
+++ b/README.md
@@ -470,6 +470,8 @@ docker pull ghcr.io/swisstopo/swissgeol-boreholes-dataextraction-api:edge
 docker run -d --name swissgeol-boreholes-dataextraction-api -e AWS_ACCESS_KEY_ID=XXX -e AWS_SECRET_ACCESS_KEY=YYY -e AWS_S3_BUCKET=AAA -e AWS_ENDPOINT=ZZZ -p 8000:8000 ghcr.io/swisstopo/swissgeol-boreholes-dataextraction-api:TAG
 ```
 
+Where XXX, YYY, AAA, ZZZ, and TAG are placeholder values that users should replace with their actual credentials and desired tag. 
+
 Adjust the port mapping (8000:8000) based on the app's requirements.
 
 NOTE: Do not forget to specify your AWS Credentials.

--- a/src/app/common/config.py
+++ b/src/app/common/config.py
@@ -11,6 +11,14 @@ def get_aws_bucket_name() -> str:
     return os.getenv("AWS_S3_BUCKET") if os.getenv("AWS_S3_BUCKET") else "stijnvermeeren-boreholes-integration-tmp"
 
 
+def get_aws_endpoint() -> str:
+    """Get the AWS endpoint."""
+    bucket_name = get_aws_bucket_name()
+    endpoint_name = os.getenv("AWS_ENDPOINT")
+    endpoint_str = f"https://{bucket_name}.{endpoint_name.replace('https://', '')}" if endpoint_name else None
+    return endpoint_str
+
+
 class Config(BaseSettings):
     """Configuration for the backend."""
 
@@ -32,7 +40,7 @@ class Config(BaseSettings):
     ###########################################################
     aws_access_key_id: str | None = os.environ.get("AWS_ACCESS_KEY_ID")
     aws_secret_access_key: str | None = os.environ.get("AWS_SECRET_ACCESS_KEY")
-    aws_endpoint: str | None = os.environ.get("AWS_ENDPOINT")
+    aws_endpoint: str | None = get_aws_endpoint()
 
 
 config = Config()

--- a/src/app/common/config.py
+++ b/src/app/common/config.py
@@ -11,12 +11,13 @@ def get_aws_bucket_name() -> str:
     return os.getenv("AWS_S3_BUCKET") if os.getenv("AWS_S3_BUCKET") else "stijnvermeeren-boreholes-integration-tmp"
 
 
-def get_aws_endpoint() -> str:
+def get_aws_endpoint() -> str | None:
     """Get the AWS endpoint."""
     bucket_name = get_aws_bucket_name()
     endpoint_name = os.getenv("AWS_ENDPOINT")
-    endpoint_str = f"https://{bucket_name}.{endpoint_name.replace('https://', '')}" if endpoint_name else None
-    return endpoint_str
+    if endpoint_name:
+        return f"https://{bucket_name}.{endpoint_name.removeprefix('https://')}"
+    return None
 
 
 class Config(BaseSettings):


### PR DESCRIPTION
After a discussion with the Geowerkstatt team, it seems that the Borehole API is specifying the environment slightly differently than expected.

`AWS_ENDPOINT` does not contain the name of the bucket but only the domain and the AWS Region
`AWS_S3_BUCKET` this environment variable was added to get the name of the bucket to parse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new environment variable for AWS S3 bucket configuration.
	- Enhanced AWS endpoint generation for improved flexibility.
  
- **Documentation**
	- Expanded and clarified the README.md to include detailed project overview, extracted properties, developer guidance, and new environment variable requirements.
  
- **Bug Fixes**
	- Updated debugging configuration to ensure proper Python interpreter path is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->